### PR TITLE
Add CDN links

### DIFF
--- a/cdn-links.mdx
+++ b/cdn-links.mdx
@@ -6,23 +6,55 @@ title: CDN Links
 
 A client to connect to the Polybase decentralized database.
 
+Install: 
+
 ```html
 <script src = 'https://cdn.jsdelivr.net/npm/@polybase/client@0.3.22/dist/bundle.min.js'></script>
+```
+
+Usage:
+
+```js
+// Access methods with global variable 'polybase'
+const db = polybase.client({
+  defaultNamespace: "your-namespace",
+})
 ```
 
 ## Polybase Eth
 
 A set of ethereum helpers based on EIP-1193, to make signing requests easier on Polybase.
 
+Install: 
+
 ```html
 <script src = 'https://cdn.jsdelivr.net/npm/@polybase/eth@0.3.22/dist/bundle.min.js'></script>
+```
+
+Usage:
+
+```js
+// Access methods with global variable 'polybase_eth'
+const data = 'Some data to be encrypted'
+const address = '0xADDRESS_TO_ENCRYPT_WITH'
+const encryptedData = polybase_eth.encrypt(data,address)
 ```
 
 ## Polybase Util
 
 A utility library to help support common Polybase utility functions.
 
+Install: 
+
 ```html
 <script src = 'https://cdn.jsdelivr.net/npm/@polybase/util@0.3.22/dist/bundle.min.js'></script>
+```
+
+Usage:
+
+```js
+//Access methods with the global variable 'polybase_util'
+const encodedString = '0xSOME_ENCODED_DATA'
+const data = polybase_util.decodeFromString(encodedString, 'hex')
 ```
 

--- a/cdn-links.mdx
+++ b/cdn-links.mdx
@@ -1,0 +1,28 @@
+---
+title: CDN Links
+---
+
+## Polybase Client
+
+A client to connect to the Polybase decentralized database.
+
+```html
+<script src = 'https://cdn.jsdelivr.net/npm/@polybase/client@0.3.22/dist/bundle.min.js'></script>
+```
+
+## Polybase Eth
+
+A set of ethereum helpers based on EIP-1193, to make signing requests easier on Polybase.
+
+```html
+<script src = 'https://cdn.jsdelivr.net/npm/@polybase/eth@0.3.22/dist/bundle.min.js'></script>
+```
+
+## Polybase Util
+
+A utility library to help support common Polybase utility functions.
+
+```html
+<script src = 'https://cdn.jsdelivr.net/npm/@polybase/util@0.3.22/dist/bundle.min.js'></script>
+```
+

--- a/cdn-links.mdx
+++ b/cdn-links.mdx
@@ -9,7 +9,7 @@ A client to connect to the Polybase decentralized database.
 Install: 
 
 ```html
-<script src = 'https://cdn.jsdelivr.net/npm/@polybase/client@0.3.22/dist/bundle.min.js'></script>
+<script src = 'https://cdn.jsdelivr.net/npm/@polybase/client@0.3/dist/bundle.min.js'></script>
 ```
 
 Usage:
@@ -28,7 +28,7 @@ A set of ethereum helpers based on EIP-1193, to make signing requests easier on 
 Install: 
 
 ```html
-<script src = 'https://cdn.jsdelivr.net/npm/@polybase/eth@0.3.22/dist/bundle.min.js'></script>
+<script src = 'https://cdn.jsdelivr.net/npm/@polybase/eth@0.3/dist/bundle.min.js'></script>
 ```
 
 Usage:
@@ -37,7 +37,7 @@ Usage:
 // Access methods with global variable 'polybase_eth'
 const data = 'Some data to be encrypted'
 const address = '0xADDRESS_TO_ENCRYPT_WITH'
-const encryptedData = polybase_eth.encrypt(data,address)
+const encryptedData = polybase_eth.encrypt(data, address)
 ```
 
 ## Polybase Util
@@ -47,7 +47,7 @@ A utility library to help support common Polybase utility functions.
 Install: 
 
 ```html
-<script src = 'https://cdn.jsdelivr.net/npm/@polybase/util@0.3.22/dist/bundle.min.js'></script>
+<script src = 'https://cdn.jsdelivr.net/npm/@polybase/util@0.3/dist/bundle.min.js'></script>
 ```
 
 Usage:

--- a/get-started.mdx
+++ b/get-started.mdx
@@ -16,32 +16,31 @@ npm install @polybase/client
 yarn add @polybase/client
 ```
 
-</CodeGroup>
-
-From CDN:
-
-```html
-<script src = 'https://cdn.jsdelivr.net/npm/@polybase/client@0.3.16/dist/bundle.min.js'></script>
+```bash html
+<scrip src = 'https://cdn.jsdelivr.net/npm/@polybase/client@0.3/dist/bundle.min.js'></script>
 ```
+
+</CodeGroup>
 
 ## Initialize the library
 
-From Package Manager:
-
-```js
+<CodeGroup>
+```bash js
 import { Polybase } from "@polybase/client";
 
 const db = new Polybase({
   defaultNamespace: "your-namespace",
 });
 ```
-From CDN:
 
-```js
+```bash html
 const db = polybase.client({
   defaultNamespace: "your-namespace",
 })
 ```
+
+</CodeGroup>
+
 
 <Warning>Namespace must be used for collections.</Warning>
 

--- a/get-started.mdx
+++ b/get-started.mdx
@@ -4,6 +4,8 @@ title: "Get Started"
 
 ## Install Polybase
 
+From Package Manager:
+
 <CodeGroup>
 
 ```bash npm
@@ -16,7 +18,15 @@ yarn add @polybase/client
 
 </CodeGroup>
 
+From CDN:
+
+```html
+<script src = 'https://cdn.jsdelivr.net/npm/@polybase/client@0.3.16/dist/bundle.min.js'></script>
+```
+
 ## Initialize the library
+
+From Package Manager:
 
 ```js
 import { Polybase } from "@polybase/client";
@@ -24,6 +34,13 @@ import { Polybase } from "@polybase/client";
 const db = new Polybase({
   defaultNamespace: "your-namespace",
 });
+```
+From CDN:
+
+```js
+const db = polybase.client({
+  defaultNamespace: "your-namespace",
+})
 ```
 
 <Warning>Namespace must be used for collections.</Warning>

--- a/mint.json
+++ b/mint.json
@@ -70,10 +70,7 @@
         "known-issues",
         "indexer-network",
         "indexers",
-        {
-          "group": "Resources",
-          "pages": ["cdn-links"]
-        },
+        "cdn-links",
         {
           "group": "Examples",
           "pages": ["polybase-social"]

--- a/mint.json
+++ b/mint.json
@@ -71,6 +71,10 @@
         "indexer-network",
         "indexers",
         {
+          "group": "Resources",
+          "pages": ["cdn-links"]
+        },
+        {
           "group": "Examples",
           "pages": ["polybase-social"]
         }


### PR DESCRIPTION
Hey Calum, 
I added the CDN info into a new 'Resources' tab. I figured that could be useful in the future, let me know if you want me to add any more pages there (Github/explorer links). I also added some examples of importing the package from CDN in the "Getting Started" page. 