### PR TITLE
ENG-501 (allow array of PublicKey) - Updated collections.mdx.

### DIFF
--- a/collections.mdx
+++ b/collections.mdx
@@ -200,7 +200,7 @@ The following types are supported:
 - `bytes`
 - `PublicKey`
 - `Collection`
-- `string[]`, `number[]`, `boolean[]` and `Collection*[]`
+- `string[]`, `number[]`, `boolean[]`, `PublicKey[]` and `Collection*[]`
 - `map<string | number, T>`
 
 Where `Collection*` is the name of a specific collection in the same namespace.
@@ -324,7 +324,7 @@ and the hexidecimal representation of the 64 byte public key.
 
 #### Arrays
 
-You can create arrays of `string`, `number`, `boolean` and `Collection` type. For example:
+You can create arrays of `string`, `number`, `boolean`, `PublicKey` and `Collection` type. For example:
 
 ```js
 @public
@@ -334,6 +334,7 @@ collection User {
   ages: number[];
   attempts: boolean[];
   friends: User[];
+  keys: PublicKey[];
 }
 ```
 


### PR DESCRIPTION
This is PR 3 of the feature, ENG-501 - allow array of Public Key.

Changes made:
  * Updated relevant sections and added `PublicKey`.

Depends on (no functional dependency):

  *  https://github.com/polybase/polylang/pull/76
  *  https://github.com/polybase/polybase-ts/pull/130
  *  https://github.com/polybase/polybase-rust/pull/91