### PR TITLE
Forbid the use of reserved words and keywords (JS) in Polybase schemas

### DIFF
--- a/collections.mdx
+++ b/collections.mdx
@@ -18,6 +18,12 @@ action.
 
 ## Create a collection
 
+<Warning>
+  Note that reserved words and keywords (JavaScript) may not be used as identifiers (fields, function names etc.).
+
+  Please refer to this for the full list of [reserved words](https://tc39.es/ecma262/#sec-keywords-and-reserved-words).
+</Warning>
+
 ### Create collection using the Explorer (recommended)
 
 Navigate to the [Explorer](https://explorer.testnet.polybase.xyz), and click on "Create Collection". You will then be prompted to sign in.

--- a/get-started.mdx
+++ b/get-started.mdx
@@ -47,13 +47,13 @@ const db = polybase.Polybase({
   If you specify a defaultNamespace, it will be automatically added for you when you [create a collection instance](/collections#get-a-collection).
 </Info>
 
-## Naming restrictions
-
-<Warning> Note that reserved words and keywwords (JavaScript) may not be used as identifiers (fields, function names etc.).</Warning>
-
-Please refer to this for the full list of [reserved words](https://tc39.es/ecma262/#sec-keywords-and-reserved-words).
-
 ## Create a collection
+
+<Warning>
+  Note that reserved words and keywords (JavaScript) may not be used as identifiers (fields, function names etc.).
+
+  Please refer to this for the full list of [reserved words](https://tc39.es/ecma262/#sec-keywords-and-reserved-words).
+</Warning>
 
 You must create a collection before writing and reading data to Polybase. Create collections using [Polybase Explorer](https://explorer.testnet.polybase.xyz) **(recommended)** or programatically [using the JavaScript SDK](/collections#create-collection-programmatically).
 

--- a/get-started.mdx
+++ b/get-started.mdx
@@ -47,6 +47,12 @@ const db = polybase.Polybase({
   If you specify a defaultNamespace, it will be automatically added for you when you [create a collection instance](/collections#get-a-collection).
 </Info>
 
+## Naming restrictions
+
+<Warning> Note that reserved words and keywwords (JavaScript) may not be used as identifiers (fields, function names etc.).</Warning>
+
+Please refer to this for the full list of [reserved words](https://tc39.es/ecma262/#sec-keywords-and-reserved-words).
+
 ## Create a collection
 
 You must create a collection before writing and reading data to Polybase. Create collections using [Polybase Explorer](https://explorer.testnet.polybase.xyz) **(recommended)** or programatically [using the JavaScript SDK](/collections#create-collection-programmatically).


### PR DESCRIPTION
Changes:
 - Added sub-section indicating the list of restricted words/keywords.
