### PR TITLE
ENG-1085: Add `contract` as a reserved word

### DIFF
--- a/collections.mdx
+++ b/collections.mdx
@@ -19,9 +19,11 @@ action.
 ## Create a collection
 
 <Warning>
-  Note that reserved words and keywords (JavaScript) may not be used as identifiers (fields, function names etc.).
+  `contract` may **not** be used as an identifier (collection name, field name, function name, etc.).
 
-  Please refer to this for the full list of [reserved words](https://tc39.es/ecma262/#sec-keywords-and-reserved-words).
+  Also, JavaScript reserved words and keywords may **not** be used as identifiers. 
+
+  Please refer to the full list of [JavaScript reserved words](https://tc39.es/ecma262/#sec-keywords-and-reserved-words).
 </Warning>
 
 ### Create collection using the Explorer (recommended)


### PR DESCRIPTION
Changes:
  - added `contract` as a reserved word.